### PR TITLE
Generally improve ansible-playbook and add dynamic completions

### DIFF
--- a/_ansible-playbook
+++ b/_ansible-playbook
@@ -14,6 +14,8 @@
 
 
 _arguments -C \
+  '(- *)'{-h,--help}'[show this help message and exit]' \
+  '(- *)--version[show program'"'"'s version number and exit]' \
   '(--ask-pass -k)'{-k,--ask-pass}'[ask for SSH password]' \
   '(--ask-su-pass)--ask-su-pass[ask for su password]' \
   '(--ask-sudo-pass -K)'{-K,--ask-sudo-pass}'[ask for sudo password]' \
@@ -25,7 +27,6 @@ _arguments -C \
   '(--flush-cache)--flush-cache[clear the fact cache]' \
   '(--force-handlers)--force-handlers[run handlers even if a task fails]' \
   '(--forks -f)'{-f\ FORKS,--forks=FORKS}'[specify number of parallel processes to use (default=5)]' \
-  '(--help -h)'{-h,--help}'[show this help message and exit]' \
   '(--inventory -i-file)'{-i\ INVENTORY,--inventory-file=INVENTORY}'[specify inventory host file (default=/etc/ansible/hosts)]' \
   '(--limit -l)'{-l\ SUBSET,--limit=SUBSET}'[further limit selected hosts to an additional pattern]' \
   '(--list-hosts)--list-hosts[outputs a list of matching hosts; does not execute anything else]' \
@@ -45,5 +46,4 @@ _arguments -C \
   '(--user -u)'{-u\ REMOTE_USER,--user=REMOTE_USER}'[connect as this user (default=logged_in_user)]' \
   '(--vault-password-file=VAULT_PASSWORD_FILE)--vault-password-file=VAULT_PASSWORD_FILE[vault password file]' \
   '(--verbose -v)'{-v,--verbose}'[verbose mode (-vvv for more, -vvvv to enable connection debugging)]' \
-  '(--version)--version[show program'"'"'s version number and exit]' \
   '*:files:_files' \

--- a/_ansible-playbook
+++ b/_ansible-playbook
@@ -13,6 +13,9 @@
 #
 
 
+local context state state_descr line
+typeset -A opt_args
+
 _arguments -C \
   '(- *)'{-h,--help}'[show this help message and exit]' \
   '(- *)--version[show program'"'"'s version number and exit]' \
@@ -34,7 +37,7 @@ _arguments -C \
   '(--module-path -M)'{-M\ MODULE_PATH,--module-path=MODULE_PATH}'[specify path(s) to module library (default=None)]' \
   '(--private-key)--private-key=PRIVATE_KEY_FILE[use this file to authenticate the connection]' \
   '(--skip-tags)--skip-tags=SKIP_TAGS[only run plays and tasks whose tags do not match these values]' \
-  '(--start-at-task)--start-at-task=[start the playbook at the task matching this name]' \
+  '(--start-at-task)--start-at-task=[start the playbook at the task matching this name]: :->START_AT_TASK' \
   '(--step)--step[one-step-at-a-time: confirm each task before running]' \
   '(--su -S)'{-S,--su}'[run operations with su]' \
   '(--su-user -R)'{-R\ SU_USER,--su-user=SU_USER}'[run operations with su as this user (default=root)]' \
@@ -47,3 +50,14 @@ _arguments -C \
   '(--vault-password-file=VAULT_PASSWORD_FILE)--vault-password-file=VAULT_PASSWORD_FILE[vault password file]' \
   '(--verbose -v)'{-v,--verbose}'[verbose mode (-vvv for more, -vvvv to enable connection debugging)]' \
   '*:files:_files' \
+
+
+case $state in
+  START_AT_TASK)
+    tasklist=( ${(f)"$(
+      ansible-playbook --list-tasks $line 2> /dev/null | sed 's/^[ ]*//;s/[ ]*$//' | sed -r 's/[\t]+TAGS:.*//'
+    )"} )
+    compadd -V unsorted -a tasklist
+    ;;
+esac
+

--- a/_ansible-playbook
+++ b/_ansible-playbook
@@ -1,5 +1,6 @@
 #compdef ansible-playbook
-# 
+
+#
 # Description
 # -----------
 # Completion script for ansible-playbook command
@@ -11,36 +12,38 @@
 # https://github.com/jdottdot
 #
 
+
 _arguments -C \
-  '(-k --ask-pass)'{-k,--ask-pass}'[ask for SSH password]' \
+  '(--ask-pass -k)'{-k,--ask-pass}'[ask for SSH password]' \
   '(--ask-su-pass)--ask-su-pass[ask for su password]' \
-  '(-K --ask-sudo-pass)'{-K,--ask-sudo-pass}'[ask for sudo password]' \
+  '(--ask-sudo-pass -K)'{-K,--ask-sudo-pass}'[ask for sudo password]' \
   '(--ask-vault-pass)--ask-vault-pass[ask for vault password]' \
-  "(-C --check)"{-C,--check}"[don't make any changes; instead, try to predict some of the changes that may occur]" \
-  '(-c --connection)'{-c\ CONNECTION,--connection=CONNECTION}'[connection type to use (default=smart)]' \
-  '(-D --diff)'{-D,--diff}'[when changing (small) files and templates, show the differences in those files; works great with --check]' \
-  '(-e --extra-vars)'{-e\ EXTRA_VARS,--extra-vars=EXTRA_VARS}'[set additional variables as key=value or YAML/JSON]' \
-  '(-f --forks)'{-f\ FORKS,--forks=FORKS}'[specify number of parallel processes to use (default=5)]' \
+  '(--check -C)'{-C,--check}"[don't make any changes; instead, try to predict some of the changes that may occur]" \
+  '(--connection -c)'{-c\ CONNECTION,--connection=CONNECTION}'[connection type to use (default=smart)]' \
+  '(--diff -D)'{-D,--diff}'[when changing (small) files and templates, show the differences in those files; works great with --check]' \
+  '(--extra -e-vars)'{-e\ EXTRA_VARS,--extra-vars=EXTRA_VARS}'[set additional variables as key=value or YAML/JSON]' \
   '(--flush-cache)--flush-cache[clear the fact cache]' \
   '(--force-handlers)--force-handlers[run handlers even if a task fails]' \
-  '(-h --help)'{-h,--help}'[show this help message and exit]' \
-  '(-i --inventory-file)'{-i\ INVENTORY,--inventory-file=INVENTORY}'[specify inventory host file (default=/etc/ansible/hosts)]' \
-  '(-l --limit)'{-l\ SUBSET,--limit=SUBSET}'[further limit selected hosts to an additional pattern]' \
+  '(--forks -f)'{-f\ FORKS,--forks=FORKS}'[specify number of parallel processes to use (default=5)]' \
+  '(--help -h)'{-h,--help}'[show this help message and exit]' \
+  '(--inventory -i-file)'{-i\ INVENTORY,--inventory-file=INVENTORY}'[specify inventory host file (default=/etc/ansible/hosts)]' \
+  '(--limit -l)'{-l\ SUBSET,--limit=SUBSET}'[further limit selected hosts to an additional pattern]' \
   '(--list-hosts)--list-hosts[outputs a list of matching hosts; does not execute anything else]' \
   '(--list-tasks)--list-tasks[list all tasks that would be executed]' \
-  '(-M --module-path)'{-M\ MODULE_PATH,--module-path=MODULE_PATH}'[specify path(s) to module library (default=None)]' \
+  '(--module-path -M)'{-M\ MODULE_PATH,--module-path=MODULE_PATH}'[specify path(s) to module library (default=None)]' \
   '(--private-key)--private-key=PRIVATE_KEY_FILE[use this file to authenticate the connection]' \
   '(--skip-tags)--skip-tags=SKIP_TAGS[only run plays and tasks whose tags do not match these values]' \
-  '(--start-at-task)--start-at-task=START_AT[start the playbook at the task matching this name]' \
+  '(--start-at-task)--start-at-task=[start the playbook at the task matching this name]' \
   '(--step)--step[one-step-at-a-time: confirm each task before running]' \
-  '(-S --su)'{-S,--su}'[run operations with su]' \
-  '(-R --su-user)'{-R\ SU_USER,--su-user=SU_USER}'[run operations with su as this user (default=root)]' \
-  '(-s --sudo)'{-s,--sudo}'[run operations with sudo (nopasswd)]' \
-  '(-U --sudo-user)'{-U\ SUDO_USER,--sudo-user=SUDO_USER}'[desired sudo user (default=root)]' \
+  '(--su -S)'{-S,--su}'[run operations with su]' \
+  '(--su-user -R)'{-R\ SU_USER,--su-user=SU_USER}'[run operations with su as this user (default=root)]' \
+  '(--sudo -U-user)'{-U\ SUDO_USER,--sudo-user=SUDO_USER}'[desired sudo user (default=root)]' \
+  '(--sudo -s)'{-s,--sudo}'[run operations with sudo (nopasswd)]' \
   '(--syntax-check)--syntax-check[perform a syntax check on the playbook, but do not execute it]' \
-  '(-t --tags)'{-t\ TAGS,--tags=TAGS}'[only run plays and tasks tagged with these values]' \
-  '(-T,--timeout)'{-T\ TIMEOUT,--timeout=TIMEOUT}'[override the SSH timeout in seconds (default=10)]' \
-  '(-u --user)'{-u\ REMOTE_USER,--user=REMOTE_USER}'[connect as this user (default=logged_in_user)]' \
+  '(--tags -t)'{-t\ TAGS,--tags=TAGS}'[only run plays and tasks tagged with these values]' \
+  '(--timeout -T)'{-T\ TIMEOUT,--timeout=TIMEOUT}'[override the SSH timeout in seconds (default=10)]' \
+  '(--user -u)'{-u\ REMOTE_USER,--user=REMOTE_USER}'[connect as this user (default=logged_in_user)]' \
   '(--vault-password-file=VAULT_PASSWORD_FILE)--vault-password-file=VAULT_PASSWORD_FILE[vault password file]' \
-  '(-v --verbose)'{-v,--verbose}'[verbose mode (-vvv for more, -vvvv to enable connection debugging)]' \
-  "(--version)--version[show program's version number and exit]" \
+  '(--verbose -v)'{-v,--verbose}'[verbose mode (-vvv for more, -vvvv to enable connection debugging)]' \
+  '(--version)--version[show program'"'"'s version number and exit]' \
+  '*:files:_files' \

--- a/_ansible-playbook
+++ b/_ansible-playbook
@@ -30,7 +30,7 @@ _arguments -C \
   '(--flush-cache)--flush-cache[clear the fact cache]' \
   '(--force-handlers)--force-handlers[run handlers even if a task fails]' \
   '(--forks -f)'{-f\ FORKS,--forks=FORKS}'[specify number of parallel processes to use (default=5)]' \
-  '(--inventory -i-file)'{-i\ INVENTORY,--inventory-file=INVENTORY}'[specify inventory host file (default=/etc/ansible/hosts)]' \
+  '(--inventory -i-file)'{-i=,--inventory-file=}'[specify inventory host file (default=/etc/ansible/hosts)]: :_files' \
   '(--limit -l)'{-l\ SUBSET,--limit=SUBSET}'[further limit selected hosts to an additional pattern]' \
   '(--list-hosts)--list-hosts[outputs a list of matching hosts; does not execute anything else]' \
   '(--list-tasks)--list-tasks[list all tasks that would be executed]' \

--- a/_ansible-playbook
+++ b/_ansible-playbook
@@ -55,7 +55,7 @@ _arguments -C \
 case $state in
   START_AT_TASK)
     tasklist=( ${(f)"$(
-      ansible-playbook --list-tasks $line 2> /dev/null | sed 's/^[ ]*//;s/[ ]*$//' | sed -r 's/[\t]+TAGS:.*//'
+      ansible-playbook --list-tasks ${~line} 2> /dev/null | grep 'TAGS: \[' | sed 's/^[ ]*//;s/[ ]*$//' | sed -r 's/[\t]+TAGS: \[.*//'
     )"} )
     compadd -V unsorted -a tasklist
     ;;


### PR DESCRIPTION
The completion for `ansible-playbook` was not working the way the command works: no completion after first argument, option arguments were not completed...

The main improvements are support for normal arguments (the playbook file) while still completing options after them and the dynamic `--start-at-task` that completes the long task names that I had to copy/paste manually so far.

There are some other improvements, although there is room for lots of quick fixes that would bring in a lot of value for whoever uses the other options.